### PR TITLE
[BUG FIX] Multiple Neutron Network Support

### DIFF
--- a/hot/chef-server.yaml
+++ b/hot/chef-server.yaml
@@ -19,6 +19,11 @@ parameters:
     type: string
     default: OpenSourceChefServer
     description: The Instance Name
+    
+  chef_network_name:
+    type: string
+    default: private
+    description: The Name or ID of the NEtwork the Chef Server is deployed
 
   chef_port:
     type: number
@@ -40,6 +45,8 @@ resources:
   ChefServer:
     type: OS::Nova::Server
     properties:
+      networks: 
+        - network: { get_param: chef_network_name }
       flavor: { get_param: chef_flavor_name }
       image: { get_param: chef_image_name }
       name: { get_param: chef_server_name }


### PR DESCRIPTION
BugFix for: Resource CREATE failed: Conflict: resources.ChefServer: Multiple possible networks found, use a Network ID to be more specific. (HTTP 409)

Defines a fild for the network where the chef-server has to be deployed.