### PR TITLE
Install os-collect-config prereqs so that it runs without errors

### DIFF
--- a/hot/software-config/boot-config/templates/fragments/install_config_agent_rdo.sh
+++ b/hot/software-config/boot-config/templates/fragments/install_config_agent_rdo.sh
@@ -2,4 +2,4 @@
 set -eux
 
 yum -y install https://www.rdoproject.org/repos/rdo-release.rpm
-yum -y install python-zaqarclient os-collect-config os-apply-config os-refresh-config dib-utils
+yum -y install python2-oslo-log python-psutil python-zaqarclient os-collect-config os-apply-config os-refresh-config dib-utils


### PR DESCRIPTION
When using `-e heat-templates/hot/software-config/boot-config/centos7_rdo_env.yaml` to setup os-collect-config on instances in a heat template launched from the standard CentOS7 images provided online, the program installs but errors when cloud-init tries to run the script due to missing python packages. Installing these 2 rpms resolves the errors.